### PR TITLE
736 - API returns 401 or 500 only

### DIFF
--- a/src/middleware/authorization.js
+++ b/src/middleware/authorization.js
@@ -35,6 +35,7 @@ module.exports = {
             res.sendStatus(401);
           } else {
             req.authorization = client;
+            req.authorization.key = client[datastore.KEY].path;
             next();
           }
         });

--- a/src/routes/ingest.js
+++ b/src/routes/ingest.js
@@ -14,9 +14,10 @@ module.exports = (app) => {
 
     const uploadPath = path.join(
       config.storage.path,
-      req.authorization.code,
+      req.authorization.key[1],
       fileName,
     );
+
 
     log.debug(`Uploading ingestion data to gs://${config.storage.bucket}/${uploadPath}`);
     const upload = bucket


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/736

The 401 error described in the ticket was due to a badly configured entry in datastore. That has been fixed, but then I discovered the API returned 500 errors due to broken path. I updated the code to use the client id instead of the code.