### PR TITLE
API-123: Removes GUID validation on position ids

### DIFF
--- a/src/validations/positions.validation.ts
+++ b/src/validations/positions.validation.ts
@@ -8,7 +8,6 @@ const {
 const schema = Joi.array().items(
   Joi.object({
     id: Joi.string()
-      .guid()
       .required(),
     lat: Joi.number()
       .min(-90)


### PR DESCRIPTION
Connects to https://globalfishingwatch.atlassian.net/browse/API-123.

This allows arbitrary ids to be sent for each position, which is critical since some VMS sources using this API have custom domain-based identifiers.